### PR TITLE
Add TL;DR section to .plan/README.md

### DIFF
--- a/.plan/README.md
+++ b/.plan/README.md
@@ -1,2 +1,16 @@
 The `.design` folder is temporary. I use AI to help me do the design, plan, etc. I keep what AI generates in this folder. Content in this folder can be also used as input for furhter AI collaboration. 
 
+----- Here is a TL;DR -----
+
+## What's in the .plan folder
+
+**PoC/**: 10-week proof of concept plan for mutation testing with Python/pytest, GitHub Actions, Temporal Cloud orchestration, and basic web UI
+
+**Temporal/**: Decision to use Temporal Cloud over Argo Workflows for long-running, multi-tenant workflow orchestration with namespace isolation
+
+**Web/**: Full-stack architecture with Next.js frontend (Vercel), FastAPI backend (Fly.io), PostgreSQL (Supabase), and tenant-specific URLs
+
+**Security/**: Secrets management strategy using Doppler/AWS Secrets Manager across dev/staging/prod environments
+
+**Random/**: Miscellaneous thoughts and considerations for the project
+


### PR DESCRIPTION
## Summary
- Added TL;DR section to .plan/README.md explaining what's in each folder
- Helps collaborators quickly understand the project planning documentation structure

## Test plan
- [x] Verify the TL;DR section accurately describes folder contents
- [x] Ensure formatting is consistent with existing documentation

🤖 Generated with [Claude Code](https://claude.ai/code)