### PR TITLE
Fix relative imports in cleanup.py

### DIFF
--- a/scripts/demo/cleanup.py
+++ b/scripts/demo/cleanup.py
@@ -3,8 +3,8 @@ Cleanup functionality for mutation testing PoC.
 """
 from pathlib import Path
 from typing import List, Dict, Any
-from .repo_manager import RepoManager
-from .pr_manager import PRManager
+from repo_manager import RepoManager
+from pr_manager import PRManager
 
 
 class CleanupManager:


### PR DESCRIPTION
## Summary
- Fix relative imports in cleanup.py to support direct script execution
- Change from `from .repo_manager import RepoManager` to `from repo_manager import RepoManager`
- Change from `from .pr_manager import PRManager` to `from pr_manager import PRManager`

## Test plan
- Verified that `python demo.py` no longer throws ImportError
- Mutation testing workflow can now run without import issues

🤖 Generated with [Claude Code](https://claude.ai/code)