### PR TITLE
Fix cleanup repository parameter issue

### DIFF
--- a/scripts/demo/cleanup.py
+++ b/scripts/demo/cleanup.py
@@ -11,7 +11,7 @@ class CleanupManager:
     def __init__(self):
         self.repo_manager = RepoManager()
     
-    def cleanup_pr_and_repo(self, repo_path: Path, pr_number: str) -> Dict[str, Any]:
+    def cleanup_pr_and_repo(self, repo_path: Path, pr_number: str, repo_id: str = None) -> Dict[str, Any]:
         """Clean up pull request and local repository."""
         cleanup_results = {
             'pr_closed': False,
@@ -22,7 +22,7 @@ class CleanupManager:
         try:
             # Close the pull request
             pr_manager = PRManager(repo_path)
-            pr_manager.close_pull_request(pr_number)
+            pr_manager.close_pull_request(pr_number, repo_id)
             cleanup_results['pr_closed'] = True
         except Exception as e:
             cleanup_results['errors'].append(f"Failed to close PR: {str(e)}")

--- a/scripts/demo/demo.py
+++ b/scripts/demo/demo.py
@@ -210,7 +210,7 @@ This mutation tests whether the test suite can detect the change in {mutation_co
         # Step 8: Cleanup
         print("Cleaning up...")
         if repo_path and pr_number:
-            cleanup_results = cleanup_manager.cleanup_pr_and_repo(repo_path, pr_number)
+            cleanup_results = cleanup_manager.cleanup_pr_and_repo(repo_path, pr_number, selected_repo['repo_id'])
             print(f"Cleanup results: {cleanup_results}")
         elif repo_path:
             # Clean up repo even if PR wasn't created

--- a/scripts/demo/pr_manager.py
+++ b/scripts/demo/pr_manager.py
@@ -79,9 +79,14 @@ class PRManager:
             print(f"DEBUG: stdout: {e.stdout}")
             raise  # Re-raise for other errors
     
-    def close_pull_request(self, pr_number: str) -> None:
+    def close_pull_request(self, pr_number: str, repo: str = None) -> None:
         """Close a pull request without merging."""
         cmd = ["gh", "pr", "close", pr_number]
+        
+        # Add repo parameter if specified
+        if repo:
+            cmd.extend(["--repo", repo])
+        
         subprocess.run(cmd, cwd=self.repo_path, check=True)
     
     def wait_for_checks(self, pr_number: str, timeout_seconds: int = 300, repo: str = None) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
Fixes the cleanup phase error where GitHub CLI couldn't determine which repository to close the PR in, resulting in "No default remote repository has been set" error.

## Problem
During cleanup, the `gh pr close` command was failing because it didn't specify which repository to operate on, causing:
```
X No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help
```

## Root Cause
The `close_pull_request()` method in PRManager wasn't accepting a repository parameter, so GitHub CLI didn't know which repo context to use for closing the PR.

## Solution
• **Add repo parameter**: Update `close_pull_request()` to accept optional repo parameter
• **Update cleanup flow**: Modify `cleanup_pr_and_repo()` to pass repository information
• **Provide repo context**: Update demo.py to pass `selected_repo['repo_id']` to cleanup
• **Consistent repo handling**: Ensure all GitHub CLI commands specify target repository

## Changes Made
- **pr_manager.py**: Add `repo` parameter to `close_pull_request()` method
- **cleanup.py**: Add `repo_id` parameter to `cleanup_pr_and_repo()` method  
- **demo.py**: Pass `selected_repo['repo_id']` to cleanup call

## Test plan
- [x] Verify cleanup no longer fails with "no default repository" error
- [x] Confirm PR closure works across all three demo repositories
- [x] Test cleanup handles repository parameter correctly
- [x] Validate backward compatibility with existing cleanup calls

🤖 Generated with [Claude Code](https://claude.ai/code)