### PR TITLE
Add command line parameter for repository selection in demo.py

### DIFF
--- a/scripts/demo/demo.py
+++ b/scripts/demo/demo.py
@@ -1,9 +1,11 @@
 """
 Main entry point for mutation testing PoC demo.
 
-Usage: python demo.py
+Usage: python demo.py [repo_name]
+  repo_name: demo-httpie-cli, demo-pallets-click, or demo-psf-requests
 """
 import json
+import sys
 from pathlib import Path
 from datetime import datetime
 from repo_manager import RepoManager
@@ -119,13 +121,40 @@ def select_repo_with_timeout():
     return selected_repo
 
 
+def get_repo_by_name(repo_name):
+    """Get repository configuration by name."""
+    # Map repo names to their keys
+    repo_name_to_key = {
+        "demo-httpie-cli": "1",
+        "demo-pallets-click": "2", 
+        "demo-psf-requests": "3"
+    }
+    
+    if repo_name in repo_name_to_key:
+        key = repo_name_to_key[repo_name]
+        return REPO_OPTIONS[key]
+    else:
+        return None
+
+
 def main():
     """Main function to run the mutation testing demo."""
     print("Starting mutation testing PoC demo...")
     print()
     
     # Step 0: Select repository
-    selected_repo = select_repo_with_timeout()
+    if len(sys.argv) > 1:
+        repo_name = sys.argv[1]
+        selected_repo = get_repo_by_name(repo_name)
+        if selected_repo:
+            print(f"Using repository from command line: {selected_repo['name']}")
+        else:
+            print(f"Error: Unknown repository name '{repo_name}'")
+            print("Available repositories: demo-httpie-cli, demo-pallets-click, demo-psf-requests")
+            sys.exit(1)
+    else:
+        selected_repo = select_repo_with_timeout()
+    
     mutation_config = selected_repo["mutation"]
     
     # Generate timestamp and create dynamic names


### PR DESCRIPTION
## Summary
- Add command line parameter support to demo.py for direct repository selection
- Allow users to bypass interactive selection for automated workflows
- Maintain full backward compatibility with existing interactive selection

## Changes
- Add `sys` import for command line argument access
- Update docstring with new usage format and examples
- Add `get_repo_by_name()` function to map repo names to configurations
- Modify `main()` to check for command line arguments before interactive selection
- Add comprehensive error handling for invalid repo names
- Provide helpful error messages listing available repositories

## Usage Examples
```bash
# Interactive selection (existing behavior)
python demo.py

# Direct repository selection (new feature)
python demo.py demo-httpie-cli
python demo.py demo-pallets-click
python demo.py demo-psf-requests
```

## Benefits
- Enables automated scripting and CI/CD integration
- Reduces manual interaction for known repository selections
- Maintains user-friendly interactive mode as default
- Provides clear error messages for invalid inputs

## Test plan
- [x] Test interactive selection still works when no arguments provided
- [x] Test direct selection with valid repo names
- [x] Test error handling with invalid repo names
- [x] Verify backward compatibility with existing workflows
- [x] Test all three repository options work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)