### PR TITLE
Fix statusCheckRollup type error in test analyzer

### DIFF
--- a/scripts/demo/test_analyzer.py
+++ b/scripts/demo/test_analyzer.py
@@ -29,7 +29,15 @@ class TestAnalyzer:
         # Extract overall status
         status = pr_data.get('status', {})
         if status.get('statusCheckRollup'):
-            analysis['overall_status'] = status['statusCheckRollup'].get('state')
+            rollup = status['statusCheckRollup']
+            # Handle case where rollup is a dict
+            if isinstance(rollup, dict):
+                analysis['overall_status'] = rollup.get('state')
+            # Handle case where rollup is a list (unexpected but happens)
+            elif isinstance(rollup, list) and len(rollup) > 0 and isinstance(rollup[0], dict):
+                analysis['overall_status'] = rollup[0].get('state')
+            else:
+                analysis['overall_status'] = 'UNKNOWN'
         
         # Process individual checks
         checks = pr_data.get('checks', [])


### PR DESCRIPTION
## Summary
- Fix AttributeError when statusCheckRollup is a list instead of dict
- Add proper type checking for both dict and list cases
- Prevents crash during test result analysis phase

## Problem
The GitHub API returns `statusCheckRollup` as either a dictionary or a list depending on the PR state. The code was only handling the dictionary case, causing `'list' object has no attribute 'get'` errors.

## Solution
Added type checking to handle both cases:
- If dict: use `.get('state')` as before
- If list: extract state from first element
- If neither: default to 'UNKNOWN'

## Test plan
- [x] Tested with real PR data that caused the original error
- [x] Matches existing logic in pr_manager.py
- [x] Handles edge cases gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)